### PR TITLE
[Refact] Template 컴포넌트 리팩터링

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
+import TemplateProvider from '@/components/TemplateProvider'
 import { notoSansKrFont } from '@/styles/fonts'
-import Template from '@/ui/Template'
 import GlobalStyle from '@/styles/GlobalStyle'
 
 type ChildrenType = {
@@ -12,7 +12,7 @@ const RootLayout = ({ children }: ChildrenType) => {
       <GlobalStyle />
       <head />
       <body>
-        <Template>{children}</Template>
+        <TemplateProvider>{children}</TemplateProvider>
       </body>
     </html>
   )

--- a/src/components/TemplateProvider.tsx
+++ b/src/components/TemplateProvider.tsx
@@ -1,0 +1,16 @@
+import { NavigationTemplate, StyleTemplate } from '@/ui/Template'
+
+type ChildrenType = {
+  children: React.ReactNode
+}
+
+const TemplateProvider = ({ children }: ChildrenType) => {
+  return (
+    <>
+      <NavigationTemplate />
+      <StyleTemplate>{children}</StyleTemplate>
+    </>
+  )
+}
+
+export default TemplateProvider

--- a/src/ui/Template/NavigationTemplate.tsx
+++ b/src/ui/Template/NavigationTemplate.tsx
@@ -5,13 +5,8 @@ import SideBar from '@/ui/SideBar'
 import { useClickAway, useKeyPress, useModal } from '@/hooks'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { useEffect, useRef } from 'react'
-import * as S from './styled'
 
-type ChildrenType = {
-  children: React.ReactNode
-}
-
-const Template = ({ children }: ChildrenType) => {
+const NavigationTemplate = () => {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const {
@@ -40,9 +35,8 @@ const Template = ({ children }: ChildrenType) => {
         isSideBarOpen={isSideBarOpen}
       />
       <Header onOpen={onSideBarOpen} />
-      <S.Template>{children}</S.Template>
     </>
   )
 }
 
-export default Template
+export default NavigationTemplate

--- a/src/ui/Template/StyleTemplate.tsx
+++ b/src/ui/Template/StyleTemplate.tsx
@@ -1,7 +1,9 @@
+'use client'
+
 import BREAKPOINTS from '@/styles/BreakPoints'
 import styled from '@emotion/styled'
 
-export const Template = styled.main`
+const StyleTemplate = styled.main`
   display: flex;
   justify-content: space-around;
   padding: 18rem 16rem 10rem 16rem;
@@ -12,3 +14,5 @@ export const Template = styled.main`
     padding: 12rem 4rem 8rem 4rem;
   }
 `
+
+export default StyleTemplate

--- a/src/ui/Template/index.ts
+++ b/src/ui/Template/index.ts
@@ -1,0 +1,2 @@
+export { default as NavigationTemplate } from './NavigationTemplate'
+export { default as StyleTemplate } from './StyleTemplate'


### PR DESCRIPTION
## 이슈 번호

close #31 

## 구현 내용
- 현재 템플릿을 2가지로 나눕니다.
~~- Navigation 템플릿 -> template.tsx에서 호출~~
~~- Style 템플릿 -> layout.tsx에서 호출~~
  - NavigationTemplate, StyleTemplate 2가지 템플릿으로 분리
  - 이후에 Provider형식으로 만들어 rootLayout에서 감싸주었음.


## 구현 상세 목록
- [x] Navigation 템플릿
- [x] Style 템플릿
~~template.tsx 작성~~
- [x] TemplateProvider 작성


## 구현 영상
